### PR TITLE
Add files via upload

### DIFF
--- a/amin-fields-renamer,2,.php
+++ b/amin-fields-renamer,2,.php
@@ -149,15 +149,15 @@ function renamer_settings_custom_text_callback() {
 
 }
 
-// Renaming the post columns code
-error_log( "here" );
-
+// code to rename the post columns
 function rename_columns ( $columns ){
-  $options = get_option( 'renamer_settings' );
-  $columns ['author'] = esc_html( $options['custom-text'] );
-  return $columns;
+$options = get_option( 'renamer_settings' );
+$columns ['author'] = esc_html( $options['custom_text'] );
+return $columns;
 }
+
 add_filter ('manage_posts_columns', 'rename_columns', 30 );
+
 
 
 //Unset post admin $columns

--- a/amin-fields-renamer,2,.php
+++ b/amin-fields-renamer,2,.php
@@ -1,0 +1,180 @@
+<?php
+
+/*
+Plugin Name: Admin Fields Renamer
+Plugin URI: http://kateryna.blog
+Description: This plugin renames fields in the admin area for posts
+Author: Kateryna Kodonenko
+Author URI: http://kateryna.blog
+Text Domain: adminrenamer
+Version: 1.0
+*/
+
+
+//Add menu page for the plugin
+
+function renamer_settings_page() {
+  add_menu_page(
+    'Admin Renamer',
+    'Admin Renamer',
+    'manage_options',
+    'adminrenamer',
+    'adminrenamer_settings_page_callback',
+    'dashicons-wordpress-alt',
+    100
+  );
+}
+
+add_action( 'admin_menu', 'renamer_settings_page');
+
+//Callback for the menu page
+
+function adminrenamer_settings_page_callback(){
+  //Double check user capabilities
+  if ( !current_user_can('manage_options') ) {
+    return;
+  }
+  ?>
+  <div class="wrap">
+<!-- Form output on the settings page !-->
+  <h1><?php esc_html_e( get_admin_page_title() ); ?></h1>
+
+  <form method="post" action="options.php">
+    <!-- Display necessary hidden fields for settings -->
+    <?php settings_fields( 'renamer_settings' ); ?>
+    <!-- Display the settings sections for the page -->
+    <?php do_settings_sections( 'adminrenamer' ); ?>
+    <!-- Default Submit Button -->
+    <?php submit_button(); ?>
+  </form>
+
+</div>
+<?php
+}
+
+//Add settings page section
+
+//Check if the plugin settings exist and if don't, then create them
+function renamer_settings() {
+//if( !get_options( 'renamer_settings') ) {
+//  add_option( 'renamer_settings' );
+//}
+  // Define (at least) one section for our fields
+ add_settings_section(
+   // Unique identifier for the section
+   'renamer_settings_section',
+   // Section Title
+   __( 'Renamer Fields', 'adminrenamer' ),
+   // Callback for an optional description
+   'renamer_settings_section_callback',
+   // Admin page to add section to
+   'adminrenamer'
+ );
+
+
+//Checkbox field
+
+ add_settings_field(
+   'renamer_settings_checkbox',
+   __( 'Checkbox', 'adminrenamer'),
+   'renamer_settings_checkbox_callback',
+   'adminrenamer',
+   'renamer_settings_section',
+   [
+     'label' => 'Remove the Date Column'
+   ]
+
+ );
+
+
+add_settings_field(
+  // Unique identifier for field
+  'renamer_settings_custom_text',
+  // Field Title
+  __( 'Custom Text', 'adminrenamer'),
+  // Callback for field markup
+  'renamer_settings_custom_text_callback',
+  // Page to go on
+  'adminrenamer',
+  // Section to go in
+  'renamer_settings_section'
+);
+
+ register_setting(
+   'renamer_settings',
+   'renamer_settings'
+ );
+}
+
+add_action( 'admin_init', 'renamer_settings' );
+
+//callback for the settings sections
+
+function renamer_settings_section_callback() {
+
+    esc_html_e( 'Enter your custom names for the admin area sections', 'adminrenamer' );
+
+}
+
+//callback for the checkbox field
+
+function renamer_settings_checkbox_callback( $args ) {
+  $options = get_option( 'renamer_settings' );
+  $checkbox = '';
+  if( isset( $options[ 'checkbox' ] ) ) {
+    $checkbox = esc_html( $options['checkbox'] );
+}
+
+  $html = '<input type="checkbox" id="renamer_settings_checkbox" name="renamer_settings[checkbox]" value="1"' . checked( 1, $checkbox, false ) . '/>';
+	$html .= '&nbsp;';
+	$html .= '<label for="renamer_settings_checkbox">' . $args['label'] . '</label>';
+
+	echo $html;
+}
+
+//callback for the custom text
+
+//custom text field in the settings sections callback
+
+function renamer_settings_custom_text_callback() {
+
+  $options = get_option( 'renamer_settings' );
+
+	$custom_text = '';
+	if( isset( $options[ 'custom_text' ] ) ) {
+		$custom_text = esc_html( $options['custom_text'] );
+	}
+
+  echo '<input type="text" id="renamer_customtext" name="renamer_settings[custom_text]" value="' . $custom_text . '" />';
+
+}
+
+// Renaming the post columns code
+error_log( "here" );
+
+function rename_columns ( $columns ){
+  $options = get_option( 'renamer_settings' );
+  $columns ['author'] = esc_html( $options['custom-text'] );
+  return $columns;
+}
+add_filter ('manage_posts_columns', 'rename_columns', 30 );
+
+
+//Unset post admin $columns
+
+function my_manage_columns( $columns ) {
+ unset($columns['date']);
+ return $columns;
+}
+
+function my_column_init() {
+  $options = get_option( 'renamer_settings' );
+    if( isset( $options[ 'checkbox' ]) && $options['checkbox'] == '1' ) {
+      add_filter( 'manage_posts_columns' , 'my_manage_columns' );
+    }
+}
+
+add_action( 'admin_init' , 'my_column_init' );
+
+
+?>


### PR DESCRIPTION
The goal of this pull request is to add a new feature of adding a field for a custom text that would allow to rename "Author Column" to something else:
<img width="1024" alt="Screen Shot 2021-12-09 at 6 50 45 PM" src="https://user-images.githubusercontent.com/25575134/145493602-546046f7-b38e-4701-9bea-99babc74b7d5.png">

The base code that I am using for this is:

`
function rename_columns ( $columns ){
  $columns ['author'] = 'Writer';
  return $columns;
}

add_filter ('manage_posts_columns', 'rename_columns', 30 );`

I am then tying it up with the custom text field like so:

`
function rename_columns ( $columns ){
  $options = get_option( 'renamer_settings' );
  $columns ['author'] = esc_html( $options['custom-text'] );
  return $columns;
}
add_filter ('manage_posts_columns', 'rename_columns', 30 );`

There is a problem in the syntax in that code because instead of renaming a column, it just makes it blank. I added error_log() and spotted this bit:

[09-Dec-2021 18:48:29 UTC] PHP Parse error:  syntax error, unexpected '=' in /Users/katerynakodonenko/Local Sites/zacgordoncourse/app/public/wp-content/plugins/amin-fields-renamer copy/amin-fields-renamer.php on line 156
